### PR TITLE
ci: fix cloudflare deploy

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,10 +1,10 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  push:
-    branches:
-      - development
-  pull_request:
+  workflow_run:
+    workflows: ["Conventional Commits"]
+    types:
+      - completed
 
 jobs:
   deploy-to-cloudflare:


### PR DESCRIPTION
The current implementation of the cloudflare deploy [workflow](https://github.com/ubiquity/ts-template/blob/4680536d0df2eeb90a755504e12b8a3679e0e89a/.github/workflows/cloudflare-deploy.yml) fails for PRs from forked repos because forked repos can't read org's secrets

This PR refactors the cloudflare workflow to run on the `workflow_run` event which has access to org's secrets 
