### PR TITLE
fix: workflow fixes

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -1,10 +1,8 @@
 name: Run Cypress testing suite
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - development
   pull_request:
+    types: [ opened, synchronize ]
 
 jobs:
   cypress-run:

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,10 +1,8 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - development
   pull_request:
+    types: [ opened, synchronize ]
 
 env:
   NODE_ENV: "test"

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -2,6 +2,7 @@ name: Knip
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions: write-all
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,3 +1,4 @@
+import { mainModule } from "../static/main";
 import { db } from "./__mocks__/db";
 import { server } from "./__mocks__/node";
 import usersGet from "./__mocks__/users-get.json";
@@ -18,5 +19,6 @@ describe("User tests", () => {
     const res = await fetch("https://api.ubiquity.com/users");
     const data = await res.json();
     expect(data).toMatchObject(usersGet);
+    expect(async () => await mainModule()).not.toThrow();
   });
 });


### PR DESCRIPTION
- disabled comments on every push
- added default value for coverage

Addresses https://github.com/ubiquity/ts-template/commit/438da50c0b0c2d6e07126e49baa5846b9f4a854a#commitcomment-139372500
 https://github.com/ubiquity/series-a/commit/fb63aa17417ee1eb05ba9b1c7ad4c9b4db657b5a#commitcomment-139372521
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
