### PR TITLE
ci: add init workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build & Deploy
 
 on:
-  push:
-  pull_request:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Init"]
+    types:
+      - completed
 
 permissions:
   contents: read

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,0 +1,15 @@
+# Initializes the "build and deploy" workflow to have access to github secrets in that workflow
+name: Init
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Init
+        run: |
+          echo "Initialized"


### PR DESCRIPTION
Resolves https://github.com/ubiquity/cloudflare-deploy-action/issues/1 (partially)

This PR adds a dummy [init workflow](https://github.com/rndquu/ts-template/blob/252fbb829f2b2b0a961b513df27af2126214278c/.github/workflows/init.yml) which (on completion) triggers the [build and deploy workflow](https://github.com/rndquu/ts-template/blob/252fbb829f2b2b0a961b513df27af2126214278c/.github/workflows/build.yml) so that forked repos could have access to ubiquity org github secrets (in a safe way)

P.S. The "build and deploy" workflow is not triggered in this particular PR because it should be merged first