### PR TITLE
fix: Jest / Cypress now triggers after build, and release-please targets the main branch

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -1,8 +1,10 @@
 name: Run Cypress testing suite
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
   cypress-run:

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -21,9 +21,12 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
       - name: Jest With Coverage Comment
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           package-manager: yarn
+          prnumber: ${{ steps.findPr.outputs.number }}

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,10 +1,7 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  pull_request_target:
 
 env:
   NODE_ENV: "test"
@@ -17,15 +14,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20.10.0"
+
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - uses: jwalton/gh-find-current-pr@v1
-        id: findPr
+
       - name: Jest With Coverage Comment
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           package-manager: yarn
-          prnumber: ${{ steps.findPr.outputs.number }}
+          prnumber: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -27,7 +27,7 @@ jobs:
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()
         uses: ArtiomTr/jest-coverage-report-action@v2
-#        with:
+#        with: testing
 #          coverage-summary-path: coverage/coverage-summary.json
 #          junitxml-path: junit.xml
 #          junitxml-title: JUnit

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -3,7 +3,10 @@ on:
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize]
-
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 env:
   NODE_ENV: "test"
 

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,10 +1,8 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  pull_request_target:
+
 env:
   NODE_ENV: "test"
 

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,10 +1,12 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  pull_request_target:
+#  workflow_run:
+#    workflows: ["Build"]
+#    types:
+#      - completed
+
 env:
   NODE_ENV: "test"
 

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -17,11 +17,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20.10.0"
+
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
+
       - name: Jest With Coverage Comment
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,11 +1,10 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  pull_request_target:
-#  workflow_run:
-#    workflows: ["Build"]
-#    types:
-#      - completed
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 env:
   NODE_ENV: "test"

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,7 +1,10 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  pull_request_target:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 env:
   NODE_ENV: "test"

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -19,16 +19,9 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-#      - name: Build & Run test suite
-#        run: |
-#          yarn
-#          yarn test | tee ./coverage.txt && exit ${PIPESTATUS[0]}
-      - name: Jest Coverage Comment
+      - name: Jest With Coverage Comment
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()
         uses: ArtiomTr/jest-coverage-report-action@v2
-#        with: testing
-#          coverage-summary-path: coverage/coverage-summary.json
-#          junitxml-path: junit.xml
-#          junitxml-title: JUnit
-#          coverage-path: ./coverage.txt
+        with:
+          package-manager: yarn

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -26,5 +26,3 @@ jobs:
         with:
           package-manager: yarn
           prnumber: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
-
-# comment

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,8 +1,6 @@
 name: Run Jest testing suite
 on:
   workflow_dispatch:
-  pull_request_target:
-    types: [opened, synchronize]
   workflow_run:
     workflows: ["Build"]
     types:

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -26,3 +26,5 @@ jobs:
         with:
           package-manager: yarn
           prnumber: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
+
+# comment

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -19,16 +19,16 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - name: Build & Run test suite
-        run: |
-          yarn
-          yarn test | tee ./coverage.txt && exit ${PIPESTATUS[0]}
+#      - name: Build & Run test suite
+#        run: |
+#          yarn
+#          yarn test | tee ./coverage.txt && exit ${PIPESTATUS[0]}
       - name: Jest Coverage Comment
         # Ensures this step is run even on previous step failure (e.g. test failed)
         if: always()
-        uses: MishaKav/jest-coverage-comment@main
-        with:
-          coverage-summary-path: coverage/coverage-summary.json
-          junitxml-path: junit.xml
-          junitxml-title: JUnit
-          coverage-path: ./coverage.txt
+        uses: ArtiomTr/jest-coverage-report-action@v2
+#        with:
+#          coverage-summary-path: coverage/coverage-summary.json
+#          junitxml-path: junit.xml
+#          junitxml-title: JUnit
+#          coverage-path: ./coverage.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - $default-branch
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - $default-branch
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - $default-branch
+      - ${{ github.event.repository.default_branch }}
 
 permissions:
   contents: write
@@ -17,7 +17,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: node
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20.10.0"


### PR DESCRIPTION
`release-please` would never run because I realized that `$default-branch` only works for Workflow templates, not the actual workflow.

Jest and Cypress now trigger on `Build` step completion, allowing them to access secrets and also post results in the PR.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
