### PR TITLE
Update knip-reporter.yml

### DIFF
--- a/.github/workflows/knip-reporter.yml
+++ b/.github/workflows/knip-reporter.yml
@@ -6,6 +6,8 @@ on:
     types:
       - completed
 
+permissions: write-all
+
 jobs:
   knip-reporter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed this here https://github.com/0x4007/typescript-action/pull/3/files#diff-e300da0383d00d275266a83902a2aff8c7f62da696de4bc47ca5810e69c01ffeR9

The context is that I am building a brand new plugin template, and I started by:
1. Using GitHub's official "[TypeScript Action Starter Template](https://github.com/actions/typescript-action)"
2. Pulling in our [ts-template](https://github.com/ubiquity/ts-template)
3. Finally pulling in our [plugin-template](https://github.com/ubiquity-os/plugin-template)

Is this required?