### PR TITLE
Add New PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!---
+Insert the number of the task you are completing if within this repository or paste the URL of the task.
+Resolves https://... OR #<taskNumber>
+-->
+
+/**
+We advise that you give a brief description of your changes either that it meets
+the specification exactly as described or what you had to do outwith the spec to resolve it.
+This is not required but again, it is advised.
+*/
+
+### Changes:
+- Describe the changes you made, including any deviations from the original specification:
+  - Example: "Implemented feature ABC due to requirement XYZ."
+  
+/**
+NOTICE: This is required for all pull requests and will be requested by reviewers if not present.
+
+- Include a screenshot/video or some other visual confirmation that your changes solve the task.
+- If this is not applicable, build a unit test to prove it works as intended.
+*/
+
+### Quality Assurance (QA):
+- Provide links to any relevant testing environments or issues showcasing the end result:
+  - URL to your plugin fork or test issue in your own organization:
+  - Screenshot of any UI fixes:
+  - E2E video demonstrating the functionality:
+
+### Additional Notes:
+- Include any other relevant information or context that may help reviewers understand your changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-Resolves #
-
-<!--
-- You must link the issue number e.g. "Resolves #1234"
-- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
--->


### PR DESCRIPTION
This pull request adds a new PR template to improve the documentation and clarity of pull requests as discussed in issue #72.

Resolves #72