### PR TITLE
feat: refactor sync template workflow to work in a whitelist setting

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -47,7 +47,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git checkout -b "$pr_branch"
-          git clone https://github.com/ubiquity/ts-template template-repo
+          git clone https://github.com/zugdev/ts-template template-repo
 
           # Convert ADDITIONAL_FILES input to an array
           additional_files=""

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
+          WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json static/index.html"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
           BLACKLIST_FILES: ".github/workflows/sync-template.yml"
         run: |

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -131,6 +131,6 @@ jobs:
           if [[ -z "$existing_pr" ]]; then
             gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}" --head "$pr_branch" --base "$branch_name"
           else
-            gh pr edit "$existing_pr" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}"
+            gh pr edit "$pr_branch" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}"
             echo "Updated the existing pull request #$existing_pr."
           fi

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json static/index.html"
+          WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
           BLACKLIST_FILES: ".github/workflows/sync-template.yml"
         run: |

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -65,9 +65,15 @@ jobs:
             cp -f "template-repo/$file" "$file"
           done
 
+          # Prepare a formatted file list for the PR body
+          file_list=""
+          for file in $WHITELIST_FILES "${additional_files[@]}"; do
+            file_list+="\n- \`${file}\`"
+          done
+
           # Clean up
           rm -rf template-repo/
           git add .
           git commit -m "chore: sync template"
           git push "$original_remote" "$pr_branch"
-          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting only files in the whitelist and specified files." --head "$pr_branch" --base "$branch_name"
+          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting the following files:${file_list}" --head "$pr_branch" --base "$branch_name"

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -90,6 +90,7 @@ jobs:
               file_list+=$'\n'"- \`${file}\` (directory)"
             elif [[ -e "template-repo/$file" ]]; then
               echo "Processing file: $file"
+              mkdir -p "$file"
               cp -f "template-repo/$file" "$file"
               file_list+=$'\n'"- \`${file}\`"
             else

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -116,8 +116,8 @@ jobs:
           git add .
           git commit -m "chore: sync template" || echo "No changes to commit."
 
-          # Push changes to the remote repository
-          git push "$original_remote" "$pr_branch"
+          # Push changes to the remote repository (force is to be incremental)
+          git push "$original_remote" "$pr_branch" --force
 
           # Check for existing pull requests
           existing_pr=$(gh pr list --base "$branch_name" --head "$pr_branch" --state open --json id --jq '.[0].id')

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/workflows/sync-template.yml .github/workflows/build.yml .github/workflows/conventional-commits.yml .github/workflows/cspell.yml .github/workflows/cypress-testing.yml .github/workflows/knip-reporter.yml .github/workflows/knip.yml .github/workflows/no-empty-strings.yml .github/workflows/release-please.yml .github/pull_request_template.md .husky/ static/fonts/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
+          WHITELIST_FILES: ".github/workflows/sync-template.yml .github/workflows/build.yml .github/workflows/conventional-commits.yml .github/workflows/cspell.yml .github/workflows/cypress-testing.yml .github/workflows/knip-reporter.yml .github/workflows/knip.yml .github/workflows/no-empty-strings.yml .github/workflows/release-please.yml .github/pull_request_template.md .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
@@ -46,7 +46,18 @@ jobs:
           pr_branch="sync-template/${branch_name}"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git checkout -b "$pr_branch"
+          
+          # Check if the sync branch already exists
+          if git ls-remote --exit-code --heads origin "$pr_branch"; then
+            echo "Branch $pr_branch already exists. Fetching and updating."
+            git fetch origin "$pr_branch"
+            git checkout "$pr_branch"
+            git rebase "origin/$pr_branch"
+          else
+            echo "Creating new branch $pr_branch."
+            git checkout -b "$pr_branch"
+          fi
+
           git clone https://github.com/ubiquity/ts-template template-repo
 
           # Convert ADDITIONAL_FILES input to an array
@@ -70,7 +81,13 @@ jobs:
 
           # Clean up
           rm -rf template-repo/
+
+          # Commit
           git add .
           git commit -m "chore: sync template"
+          
+          # Push
           git push "$original_remote" "$pr_branch"
+
+          # Create PR
           gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}" --head "$pr_branch" --base "$branch_name"

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -1,0 +1,73 @@
+name: Sync branch to template
+
+on:
+  workflow_dispatch:
+    inputs:
+      additional_files:
+        description: 'Comma-separated list of additional files to sync (i.e ".github/workflows/build.yml tsconfig.json")'
+        required: false
+  schedule:
+    - cron: '14 0 1 * *'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check if repository is ts-template
+        run: |
+          if [[ "${{ github.repository }}" == "ubiquity/ts-template" ]]; then
+            echo "Skipping sync: this is the template repository."
+            exit 0
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get GitHub App token
+        uses: tibdex/github-app-token@v1.7.0
+        id: get_installation_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Sync branch to template
+        env:
+          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
+          WHITELIST_FILES: ".github/workflows/build.yml,tsconfig.json"
+          ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
+        run: |
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          original_remote=$(git remote get-url origin)
+          pr_branch="sync-template/${branch_name}"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git checkout -b "$pr_branch"
+          git clone https://github.com/ubiquity/ts-template template-repo
+
+          # Convert ADDITIONAL_FILES input to an array
+          additional_files=""
+          if [[ -n "$ADDITIONAL_FILES" ]]; then
+            IFS=',' read -r -a additional_files <<< "$ADDITIONAL_FILES"
+          fi
+
+          # Copy whitelist files from template
+          for file in $WHITELIST_FILES; do
+            cp -f "template-repo/$file" "$file"
+          done
+
+          # Copy additional files from template (if any were specified)
+          for file in "${additional_files[@]}"; do
+            cp -f "template-repo/$file" "$file"
+          done
+
+          # Clean up
+          rm -rf template-repo/
+          git add .
+          git commit -m "chore: sync template"
+          git push "$original_remote" "$pr_branch"
+          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting only files in the whitelist and specified files." --head "$pr_branch" --base "$branch_name"

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/workflows/build.yml tsconfig.json"
+          WHITELIST_FILES: ".github/workflows/sync-template.yml .github/workflows/build.yml .github/workflows/conventional-commits.yml .github/workflows/cspell.yml .github/workflows/cypress-testing.yml .github/workflows/knip-reporter.yml .github/workflows/knip.yml .github/workflows/no-empty-strings.yml .github/workflows/release-please.yml .github/pull_request_template.md .husky/ static/fonts/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -28,16 +28,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get GitHub App token
-        uses: tibdex/github-app-token@v1.7.0
-        id: get_installation_token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      # - name: Get GitHub App token
+      #   uses: tibdex/github-app-token@v1.7.0
+      #   id: get_installation_token
+      #   with:
+      #     app_id: ${{ secrets.APP_ID }}
+      #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Sync branch to template
         env:
-          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
+          #GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           WHITELIST_FILES: ".github/workflows/build.yml,tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -61,7 +61,7 @@ jobs:
             git checkout -b "$pr_branch"
           fi
 
-          git clone https://github.com/ubiquity/ts-template template-repo
+          git clone https://github.com/zugdev/ts-template template-repo
 
           # Convert WHITELIST_FILES to array
           whitelist_files=()
@@ -104,7 +104,7 @@ jobs:
           for blacklisted in "${blacklist_files[@]}"; do
             if [[ -e "$blacklisted" ]]; then
               echo "Reverting blacklisted file or directory: $blacklisted"
-              git rm -rf --cached "$blacklisted" || rm -rf "$blacklisted"
+              git restore "$blacklisted"
             fi
           done
 

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -118,10 +118,6 @@ jobs:
           # Push changes to the remote repository
           git push "$original_remote" "$pr_branch"
 
-          # Debug PR listing
-          echo "PR Branch: $pr_branch"
-          echo "Base Branch: $branch_name"
-
           # Check for existing pull requests
           existing_pr=$(gh pr list --base "$branch_name" --head "$pr_branch" --state open --json id --jq '.[0].id')
 

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       additional_files:
-        description: 'Comma-separated list of additional files to sync (i.e ".github/workflows/build.yml tsconfig.json")'
+        description: 'Comma-separated list of extra paths to sync, for example: .eslintrc,.prettierrc,.github'
         required: false
   schedule:
     - cron: '14 0 1 * *'

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -57,12 +57,14 @@ jobs:
 
           # Copy whitelist files from template
           for file in $WHITELIST_FILES; do
-            cp -f "template-repo/$file" "$file"
+            if [[ -e "template-repo/$file" ]]; then
+              cp -rf "template-repo/$file" "$file"
           done
 
           # Copy additional files from template (if any were specified)
           for file in "${additional_files[@]}"; do
-            cp -f "template-repo/$file" "$file"
+            if [[ -e "template-repo/$file" ]]; then
+              cp -rf "template-repo/$file" "$file"
           done
 
           # Prepare a formatted file list for the PR body

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -42,7 +42,7 @@ jobs:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
-          BLACKLIST_FILES: ".github/workflows/deploy.yml"
+          BLACKLIST_FILES: ".github/workflows/sync-template.yml"
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           original_remote=$(git remote get-url origin)
@@ -117,6 +117,10 @@ jobs:
 
           # Push changes to the remote repository
           git push "$original_remote" "$pr_branch"
+
+          # Debug PR listing
+          echo "PR Branch: $pr_branch"
+          echo "Base Branch: $branch_name"
 
           # Check for existing pull requests
           existing_pr=$(gh pr list --base "$branch_name" --head "$pr_branch" --state open --json id --jq '.[0].id')

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -28,8 +28,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get GitHub App token
+        uses: tibdex/github-app-token@v1.7.0
+        id: get_installation_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Sync branch to template
         env:
+          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           WHITELIST_FILES: ".github/workflows/build.yml,tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/workflows/build.yml,tsconfig.json"
+          WHITELIST_FILES: ".github/workflows/build.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
@@ -50,27 +50,22 @@ jobs:
           git clone https://github.com/ubiquity/ts-template template-repo
 
           # Convert ADDITIONAL_FILES input to an array
-          additional_files=""
+          additional_files=()
           if [[ -n "$ADDITIONAL_FILES" ]]; then
             IFS=',' read -r -a additional_files <<< "$ADDITIONAL_FILES"
           fi
 
-          # Copy whitelist files from template
-          for file in $WHITELIST_FILES; do
-            if [[ -e "template-repo/$file" ]]; then
-              cp -rf "template-repo/$file" "$file"
-          done
-
-          # Copy additional files from template (if any were specified)
-          for file in "${additional_files[@]}"; do
-            if [[ -e "template-repo/$file" ]]; then
-              cp -rf "template-repo/$file" "$file"
-          done
-
-          # Prepare a formatted file list for the PR body
+          # Prepare file list for the PR body and process each whitelist file
           file_list=""
           for file in $WHITELIST_FILES "${additional_files[@]}"; do
-            file_list+="\n- \`${file}\`"
+            if [[ -e "template-repo/$file" ]]; then
+              cp -rf "template-repo/$file" "$file"
+              file_list+="\n- \`${file}\`"
+            else
+              # Remove file from destination if not in template
+              rm -rf "$file"
+              file_list+="\n- \`${file}\` (removed)"
+            fi
           done
 
           # Clean up
@@ -78,4 +73,4 @@ jobs:
           git add .
           git commit -m "chore: sync template"
           git push "$original_remote" "$pr_branch"
-          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting the following files:${file_list}" --head "$pr_branch" --base "$branch_name"
+          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}" --head "$pr_branch" --base "$branch_name"

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -28,16 +28,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Get GitHub App token
-      #   uses: tibdex/github-app-token@v1.7.0
-      #   id: get_installation_token
-      #   with:
-      #     app_id: ${{ secrets.APP_ID }}
-      #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Sync branch to template
         env:
-          #GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           WHITELIST_FILES: ".github/workflows/build.yml,tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
         run: |

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -13,6 +13,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -27,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT }} # Personal Access Token (PAT) with repo scope
 
       - name: Get GitHub App token
         uses: tibdex/github-app-token@v1.7.0
@@ -34,12 +36,13 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
+          
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          WHITELIST_FILES: ".github/workflows/sync-template.yml .github/workflows/build.yml .github/workflows/conventional-commits.yml .github/workflows/cspell.yml .github/workflows/cypress-testing.yml .github/workflows/knip-reporter.yml .github/workflows/knip.yml .github/workflows/no-empty-strings.yml .github/workflows/release-please.yml .github/pull_request_template.md .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
+          WHITELIST_FILES: ".github/ .husky/ .eslintrc .nvmrc .prettierrc .yarnrc.yml tsconfig.json"
           ADDITIONAL_FILES: ${{ github.event.inputs.additional_files }}
+          BLACKLIST_FILES: ".github/workflows/deploy.yml"
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           original_remote=$(git remote get-url origin)
@@ -52,7 +55,7 @@ jobs:
             echo "Branch $pr_branch already exists. Fetching and updating."
             git fetch origin "$pr_branch"
             git checkout "$pr_branch"
-            git rebase "origin/$pr_branch"
+            git rebase "origin/$branch_name"
           else
             echo "Creating new branch $pr_branch."
             git checkout -b "$pr_branch"
@@ -60,34 +63,73 @@ jobs:
 
           git clone https://github.com/ubiquity/ts-template template-repo
 
-          # Convert ADDITIONAL_FILES input to an array
+          # Convert WHITELIST_FILES to array
+          whitelist_files=()
+          IFS=' ' read -r -a whitelist_files <<< "$WHITELIST_FILES"
+
+          # Convert ADDITIONAL_FILES inputs to array
           additional_files=()
           if [[ -n "$ADDITIONAL_FILES" ]]; then
             IFS=',' read -r -a additional_files <<< "$ADDITIONAL_FILES"
           fi
 
+          # Convert BLACKLIST_FILES to array
+          blacklist_files=()
+          if [[ -n "$BLACKLIST_FILES" ]]; then
+            IFS=',' read -r -a blacklist_files <<< "$BLACKLIST_FILES"
+            echo "Blacklist files: ${blacklist_files[@]}"
+          fi
+
           # Prepare file list for the PR body and process each whitelist file
           file_list=""
-          for file in $WHITELIST_FILES "${additional_files[@]}"; do
-            if [[ -e "template-repo/$file" ]]; then
-              cp -rf "template-repo/$file" "$file"
-              file_list+="\n- \`${file}\`"
+          for file in "${whitelist_files[@]}" "${additional_files[@]}"; do
+            if [[ -d "template-repo/$file" ]]; then
+              echo "Processing directory: $file"
+              mkdir -p "$file"
+              rsync -a --delete "template-repo/$file/" "$file/"
+              file_list+=$'\n'"- \`${file}\` (directory)"
+            elif [[ -e "template-repo/$file" ]]; then
+              echo "Processing file: $file"
+              cp -f "template-repo/$file" "$file"
+              file_list+=$'\n'"- \`${file}\`"
             else
-              # Remove file from destination if not in template
+              echo "Removing missing file or directory: $file"
               rm -rf "$file"
-              file_list+="\n- \`${file}\` (removed)"
+              file_list+=$'\n'"- \`${file}\` (removed)"
+            fi
+          done
+
+          # Check for blacklisted files and revert changes
+          echo "Checking for blacklisted files..."
+          for blacklisted in "${blacklist_files[@]}"; do
+            if [[ -e "$blacklisted" ]]; then
+              echo "Reverting blacklisted file or directory: $blacklisted"
+              git rm -rf --cached "$blacklisted" || rm -rf "$blacklisted"
             fi
           done
 
           # Clean up
           rm -rf template-repo/
 
-          # Commit
+          # Commit changes
           git add .
-          git commit -m "chore: sync template"
-          
-          # Push
+          git commit -m "chore: sync template" || echo "No changes to commit."
+
+          # Push changes to the remote repository
           git push "$original_remote" "$pr_branch"
 
-          # Create PR
-          gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}" --head "$pr_branch" --base "$branch_name"
+          # Check for existing pull requests
+          existing_pr=$(gh pr list --base "$branch_name" --head "$pr_branch" --state open --json id --jq '.[0].id')
+
+          # Include blacklist info in PR body if present
+          if [[ -n "$blacklist_list" ]]; then
+            file_list+=$'\n\n**Blacklisted Files**:'"$blacklist_list"
+          fi
+          
+          # Create or update the pull request
+          if [[ -z "$existing_pr" ]]; then
+            gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}" --head "$pr_branch" --base "$branch_name"
+          else
+            gh pr edit "$existing_pr" --body "This pull request merges changes from the template repository, overwriting or removing the following files:${file_list}"
+            echo "Updated the existing pull request #$existing_pr."
+          fi

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -47,7 +47,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git checkout -b "$pr_branch"
-          git clone https://github.com/zugdev/ts-template template-repo
+          git clone https://github.com/ubiquity/ts-template template-repo
 
           # Convert ADDITIONAL_FILES input to an array
           additional_files=""


### PR DESCRIPTION
Resolves #61 

The sync workflow should only propose changes automatically on shared files between repos, I agree those include some of the workflows and ts settings. What I would propose is to enable manual workflow runs with input files too. This way if you want every repo that uses the template to receive a specific new file or to create an overwriting, but not too big PR, you can do it. I believe the AI analysis even though might help, would still need a thorough review and would not reduce any time overhead. I am not sure centralizing the sync workflow is a good idea, if so we would need another way to identify which repos implement the template, to only open PRs in those. If it is really needed we can have a repos list in the workflow, but I think having the sync template in this repo and skipping when it runs here is sufficient to deliver updates to all sync-template workflows across our implementations.

1. Whitelist approach
2. Allow for inputting specific files and running manually
3. Adds sync-template to this repo and skips runs in ts-template