### PR TITLE
ci: update empty-string-checker.ts

### DIFF
--- a/.github/empty-string-checker.ts
+++ b/.github/empty-string-checker.ts
@@ -36,36 +36,10 @@ async function main() {
     if (violations.length > 0) {
       violations.forEach(({ file, line, content }) => {
         core.warning(
-          "Detected an empty string.\n\nIf this is during variable initialization, consider using a different approach.\nFor more information, visit: https://www.github.com/ubiquity/ts-template/issues/31",
-          {
-            file,
-            startLine: line,
-          }
-        );
+          `Detected an empty string.\nFile: ${file}.\nLine: ${line}.\n\nIf this is during variable initialization, consider using a different approach.\nFor more information, visit: https://www.github.com/ubiquity/ts-template/issues/31`);
       });
 
-      // core.setFailed(`${violations.length} empty string${violations.length > 1 ? "s" : ""} detected in the code.`);
-
-      await octokit.rest.checks.create({
-        owner,
-        repo,
-        name: "Empty String Check",
-        head_sha: headSha,
-        status: "completed",
-        conclusion: violations.length > 0 ? "failure" : "success",
-        output: {
-          title: "Empty String Check Results",
-          summary: `Found ${violations.length} violation${violations.length !== 1 ? "s" : ""}`,
-          annotations: violations.map((v) => ({
-            path: v.file,
-            start_line: v.line,
-            end_line: v.line,
-            annotation_level: "warning",
-            message: "Empty string found",
-            raw_details: v.content,
-          })),
-        },
-      });
+      core.setFailed(`${violations.length} empty string${violations.length > 1 ? "s" : ""} detected in the code.`);
     } else {
       core.info("No empty strings found.");
     }


### PR DESCRIPTION
Check [this](https://github.com/ubiquity-os/ubiquity-os-plugin-installer/actions/runs/11951850176/job/33316343058) failing empty string check CI run which fails with the following error:
```
Error: An error occurred: Resource not accessible by integration - https://docs.github.com/rest/checks/runs#create-a-check-run
```

The [pull_request](https://github.com/ubiquity-os/ubiquity-os-plugin-installer/blob/6ad2d0abb069113a2a96313b8c4def3d9252f673/.github/workflows/no-empty-strings.yml#L4) trigger runs in the context of a forked repository. In order to use the [checks.create()](https://github.com/ubiquity-os/ubiquity-os-plugin-installer/blob/6ad2d0abb069113a2a96313b8c4def3d9252f673/.github/empty-string-checker.ts#L49) API the workflow must use the `checks: write` [permission](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run). But forked instances can [only have](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) the `read` permission.

This PR removes the `checks.create()` call so that forked instances were not failing. This way the CI is still failing and shows meaningful warnings.

QA: https://github.com/rndquu/ts-template/actions/runs/11953756844/job/33322322490?pr=6
